### PR TITLE
Small change to the way the menu shows the main item's children.

### DIFF
--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
@@ -100,7 +100,12 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                     var linkText = useCustomLinkText ? item.GetPropertyValue<string>("linkText") : link.Name;
                     markup.Append($"<li class=\"{(content.Id == link.Id ? "current" : null)}\">");
                     markup.Append($"<a target=\"{link.Target}\" href=\"{link.Url}\">{linkText}</a>");
-                    if (showChildren && linkContent.Children.Any())
+                    var showLinkChildren = showChildren;
+                    if (item.HasValue("showLinkChildren"))
+                    {
+                        showLinkChildren = item.GetPropertyValue<string>("showLinkChildren").ToLower() == "yes";
+                    }
+                    if (showLinkChildren && linkContent.Children.Any())
                     {
                         markup.Append($"<ul class=\"{ulInnerClass}\">");
                         if (addParentToSubMenu)

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
@@ -100,12 +100,12 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                     var linkText = useCustomLinkText ? item.GetPropertyValue<string>("linkText") : link.Name;
                     markup.Append($"<li class=\"{(content.Id == link.Id ? "current" : null)}\">");
                     markup.Append($"<a target=\"{link.Target}\" href=\"{link.Url}\">{linkText}</a>");
-                    var showLinkChildren = showChildren;
-                    if (item.HasValue("showLinkChildren"))
+                    var showLinksChildren = showChildren;
+                    if (item.HasValue("showLinksChildren"))
                     {
-                        showLinkChildren = item.GetPropertyValue<string>("showLinkChildren").ToLower() == "yes";
+                        showLinksChildren = item.GetPropertyValue<string>("showLinksChildren").ToLower() == "yes";
                     }
-                    if (showLinkChildren && linkContent.Children.Any())
+                    if (showLinksChildren && linkContent.Children.Any())
                     {
                         markup.Append($"<ul class=\"{ulInnerClass}\">");
                         if (addParentToSubMenu)


### PR DESCRIPTION
This allows us to override the default 'show children' behavior for each item in the menu.
For this purpose, each item in the menu is to have a dropdownbox 'showLinkChildren' with three options:

- [empty]
- yes
- no

If there is no dropdownbox, the behavior is not affected.