### PR TITLE
Allows menus to list tags instead of children.

### DIFF
--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
@@ -84,6 +84,8 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
         {
             var mainMenu = content.GetNestedContent(property);
             var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+            var umbracoContext = umbracoHelper.UmbracoContext;
+            var currentPage = umbracoContext.ContentCache.GetById(umbracoContext.PageId.Value);
             var markup = new StringBuilder();
             foreach (var item in mainMenu)
             {
@@ -98,7 +100,7 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                         continue;
                     }
                     var linkText = useCustomLinkText ? item.GetPropertyValue<string>("linkText") : link.Name;
-                    markup.Append($"<li class=\"{(content.Id == link.Id ? "current" : null)}\">");
+                    markup.Append($"<li class=\"{(currentPage.IsDescendantOrSelf(linkContent) ? "current" : null)}\">");
                     markup.Append($"<a target=\"{link.Target}\" href=\"{link.Url}\">{linkText}</a>");
                     var showLinksChildren = showChildren;
                     if (item.HasValue("showLinksChildren"))
@@ -121,11 +123,11 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                         {
                             if (addParentToSubMenu)
                             {
-                                markup.Append($"<li><a target=\"{ link.Target}\" href=\"{ link.Url}\">{link.Name}</a></li>");
+                                markup.Append($"<li><a target=\"{link.Target}\" href=\"{link.Url}\">{link.Name}</a></li>");
                             }
                             foreach (var child in linkContent.ChildrenVisible())
                             {
-                                markup.Append($"<li><a href=\"{child.Url}\">{child.Name}</a></li>");
+                                markup.Append($"<li class=\"{(currentPage.IsDescendantOrSelf(child) ? "current" : null)}\"><a href=\"{child.Url}\">{child.Name}</a></li>");
                             }
                         }
                         markup.Append("</ul>");

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Menus.cs
@@ -105,21 +105,28 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                     {
                         showLinksChildren = item.GetPropertyValue<string>("showLinksChildren").ToLower() == "yes";
                     }
-                    if (showLinksChildren && linkContent.Children.Any())
+                    if (showLinksChildren)
                     {
                         markup.Append($"<ul class=\"{ulInnerClass}\">");
-                        if (addParentToSubMenu)
+                        if (item.HasValue("tagsProperty"))
                         {
-                            markup.Append($"<li><a target=\"{ link.Target}\" href=\"{ link.Url}\">{link.Name}</a></li>");
-                        }
-                        foreach (var child in linkContent.ChildrenVisible())
-                        {
-                            var childIsHidden = child.GetPropertyValue<bool>("umbracoNaviHide");
-                            if (childIsHidden)
+                            var tagsProperty = item.GetPropertyValue<string>("tagsProperty");
+                            var tags = linkContent.ChildrenVisible().GetAllTags(tagsProperty);
+                            foreach (var tag in tags)
                             {
-                                continue;
+                                markup.Append($"<li><a href=\"{linkContent.Url}#{tag.SanitizeTagName()}\">{tag}</a></li>");
                             }
-                            markup.Append($"<li><a href=\"{child.Url}\">{child.Name}</a></li>");
+                        }
+                        else if (linkContent.ChildrenVisible().Any())
+                        {
+                            if (addParentToSubMenu)
+                            {
+                                markup.Append($"<li><a target=\"{ link.Target}\" href=\"{ link.Url}\">{link.Name}</a></li>");
+                            }
+                            foreach (var child in linkContent.ChildrenVisible())
+                            {
+                                markup.Append($"<li><a href=\"{child.Url}\">{child.Name}</a></li>");
+                            }
                         }
                         markup.Append("</ul>");
                     }
@@ -128,7 +135,6 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                 else if (link.Type == LinkType.External)
                 {
                     markup.Append($"<li><a href=\"{link.Url}\">{link.Name}</a></li>");
-
                 }
             }
             return new HtmlString(markup.ToString());

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Tags.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Tags.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Umbraco.Core.Models;
 using Umbraco.Web;
 
@@ -61,6 +62,18 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
                 }
             }
             return docList;
+        }
+
+        /// <summary>
+        /// Removes unwanted characters from tag name so that it works with javascript plugins
+        /// </summary>
+        /// <param name="tagName"></param>
+        /// <returns></returns>
+        public static string SanitizeTagName(this string tagName)
+        {
+            tagName = tagName ?? string.Empty;
+            Regex rgx = new Regex("[^a-zA-Z, ]");
+            return rgx.Replace(tagName, "").ToLower().Replace(" ", "-");
         }
     }
 }


### PR DESCRIPTION
This addition allows tags to be listed in menus instead of the element's children.
There is a field for each item in the menu called **Tags property**. When it is filled, the item will gather the tags from the children and list them.
This fulfills a request for Royal Crescent.