### PR TITLE
Adds two methods to get the contents of the MultiUrlPicker's links.

### DIFF
--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/MultiUrlPicker.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/MultiUrlPicker.cs
@@ -40,6 +40,41 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
         }
 
         /// <summary>
+        /// Gets the links as a collection of IPublishedContent. Check for null.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="property"></param>
+        /// <param name="recursive"></param>
+        /// <returns></returns>
+        public static IEnumerable<IPublishedContent> GetLinksContent(this IPublishedContent content, string property, bool recursive = false)
+        {
+            var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+            var links = content.GetLinks(property, recursive);
+            var linksContent = new List<IPublishedContent>();
+            foreach (var link in links)
+            {
+                if (link != null)
+                {
+                    linksContent.Add(umbracoHelper.TypedContent(link.Id));
+                }
+            }
+            return linksContent;
+        }
+
+        /// <summary>
+        /// Gets the link as IPublishedContent. Check for null.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="property"></param>
+        /// <param name="recursive"></param>
+        /// <returns></returns>
+        public static IPublishedContent GetLinkContent(this IPublishedContent content, string property, bool recursive = false)
+        {
+            var linksContent = content.GetLinksContent(property, recursive);
+            return linksContent.Any() ? linksContent.First() : default(IPublishedContent);
+        }
+
+        /// <summary>
         /// Works for SingleUrlPicker and MultiUrlPicker. Shows the full html link or collection of links.
         /// </summary>
         /// <param name="item"></param>

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/MultiUrlPicker.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/MultiUrlPicker.cs
@@ -53,7 +53,7 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
             var linksContent = new List<IPublishedContent>();
             foreach (var link in links)
             {
-                if (link != null)
+                if (link != null && link.Type == LinkType.Content)
                 {
                     linksContent.Add(umbracoHelper.TypedContent(link.Id));
                 }
@@ -71,7 +71,7 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
         public static IPublishedContent GetLinkContent(this IPublishedContent content, string property, bool recursive = false)
         {
             var linksContent = content.GetLinksContent(property, recursive);
-            return linksContent.Any() ? linksContent.First() : default(IPublishedContent);
+            return linksContent.FirstOrDefault();
         }
 
         /// <summary>

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/MultiUrlPicker.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/MultiUrlPicker.cs
@@ -40,7 +40,7 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
         }
 
         /// <summary>
-        /// Gets the links as a collection of IPublishedContent. Check for null.
+        /// Gets the links as a collection of IPublishedContent.
         /// </summary>
         /// <param name="content"></param>
         /// <param name="property"></param>


### PR DESCRIPTION
Add a couple of utility methods. Avoids having to check the links for null. Still will need to check the result for null.