### PR TITLE
Added v7.7 helper methods to get strongly typed settings.

### DIFF
--- a/Endzone.Umbraco.Extensions/Endzone.Umbraco.Extensions.csproj
+++ b/Endzone.Umbraco.Extensions/Endzone.Umbraco.Extensions.csproj
@@ -275,6 +275,7 @@
     <Compile Include="PublishedContentExtensions\Collections.cs" />
     <Compile Include="Services\EmailService.cs" />
     <Compile Include="UrlExtensions.cs" />
+    <Compile Include="ViewDataDictionaryExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Configuration.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Configuration.cs
@@ -42,6 +42,12 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
 
         /// <summary>
         /// Gets the strongly typed auxiliary content (e.g. website settings) for the current site.
+        /// Example:
+        /// Homepage node has a composition doc type of AuxiliaryFolder (strongly-typed interface: IAuxiliaryFolder)
+        /// which has a property called WebsiteSettings (MNTP limited to doc type WebsiteSettings).
+        /// To get the website settings on the current node call: 
+        /// Model.GetAuxiliaryContent&lt;IAuxiliaryFolder, WebsiteSettings&gt;(x => x.WebsiteSettings)
+        /// This will return the selected WebsiteSettings node with its strongly-typed model.
         /// </summary>
         /// <param name="content"></param>
         /// <param name="property">The strongly typed property that contains the MNTP value for the auxiliary content</param>

--- a/Endzone.Umbraco.Extensions/UrlExtensions.cs
+++ b/Endzone.Umbraco.Extensions/UrlExtensions.cs
@@ -1,11 +1,11 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using System.Web;
 
 namespace Endzone.Umbraco.Extensions
 {
     public static class UrlExtensions
     {
-
         /// <summary>
         /// Sets a query parameter in the url
         /// </summary>
@@ -25,6 +25,40 @@ namespace Endzone.Umbraco.Extensions
             queryParts[paramName] = value.ToString();
 
             return baseUrl + '?' + queryParts + hash;
+        }
+
+        /// <summary>
+        /// Turns relative URL into an absolute URL using the current request host.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public static string ToAbsoluteUrl(this string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                // empty URL
+                return url;
+            }
+
+            if (!Uri.IsWellFormedUriString(url, UriKind.Relative))
+            {
+                // URL is not relative
+                return url;
+            }
+
+            var httpContext = HttpContext.Current;
+
+            if (httpContext?.Request?.Url == null)
+            {
+                // HttpContext or request URL are missing
+                return url;
+            }
+
+            var requestHostUri = new Uri(httpContext.Request.Url.GetLeftPart(UriPartial.Authority));
+
+            var absoluteUri = new Uri(requestHostUri, url);
+
+            return absoluteUri.ToString();
         }
     }
 }

--- a/Endzone.Umbraco.Extensions/ViewDataDictionaryExtensions.cs
+++ b/Endzone.Umbraco.Extensions/ViewDataDictionaryExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+
+namespace Endzone.Umbraco.Extensions
+{
+    public static class ViewDataDictionaryExtensions
+    {
+        /// <summary>
+        /// Clones the existing ViewDataDictionary into a new object.
+        /// </summary>
+        /// <param name="viewData"></param>
+        /// <returns></returns>
+        public static ViewDataDictionary Clone(this ViewDataDictionary viewData)
+        {
+            if (viewData == null)
+            {
+                return null;
+            }
+
+            return new ViewDataDictionary(viewData);
+        }
+
+        /// <summary>
+        /// Extends the existing ViewDataDictionary with the specified items.
+        /// Example:
+        /// Pass a new ViewData object to a partial view and extend it with a custom value:
+        /// @Html.Partial("MyPartial", Model, ViewData.Clone().Extend(new KeyValuePair&lt;string, object&gt;("IsMobileNav", true))
+        /// </summary>
+        /// <param name="viewData"></param>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public static ViewDataDictionary Extend(this ViewDataDictionary viewData, params KeyValuePair<string, object>[] items)
+        {
+            if (viewData == null || items == null || !items.Any())
+            {
+                return viewData;
+            }
+
+            foreach (var item in items)
+            {
+                if (viewData.ContainsKey(item.Key))
+                {
+                    // replace the existing item
+                    viewData[item.Key] = item.Value;
+                }
+                else
+                {
+                    // add the new item
+                    viewData.Add(item);
+                }
+            }
+
+            return viewData;
+        }
+    }
+}


### PR DESCRIPTION
GetAuxiliaryContent is a method to get a strongly-typed model of the website settings:
`Model.GetAuxiliaryContent<IAuxiliaryFolder, WebsiteSettings>(x => x.WebsiteSettings)`

ToAbsoluteUrl is a method to convert a relative URL to an absolute URL, for example for getting the absolute URL of a media item:
`Model.OgpImage.GetCropUrl("1200x1200").ToAbsoluteUrl()`
