### PR TITLE
Added property value converter for Switcher and UmbracoContextHelper

### DIFF
--- a/Endzone.Umbraco.Extensions/Endzone.Umbraco.Extensions.csproj
+++ b/Endzone.Umbraco.Extensions/Endzone.Umbraco.Extensions.csproj
@@ -262,7 +262,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\UmbracoContextHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyValueConverters\SwitcherValueConverter.cs" />
     <Compile Include="PublishedContentExtensions\Configuration.cs" />
     <Compile Include="PublishedContentExtensions\ContentDate.cs" />
     <Compile Include="PublishedContentExtensions\LanguageVariants .cs" />

--- a/Endzone.Umbraco.Extensions/Helpers/UmbracoContextHelper.cs
+++ b/Endzone.Umbraco.Extensions/Helpers/UmbracoContextHelper.cs
@@ -12,6 +12,19 @@ namespace Endzone.Umbraco.Extensions.Helpers
         /// <summary>
         /// Ensures UmbracoContext exists for current request by either using existing one, or creating one based on the current request.
         /// </summary>
+        /// <example>
+        /// A custom PluginController that gets called outside the Umbraco context (route created using the RouteTable.Routes.MapRoute method):
+        /// public class MyPluginController : PluginController
+        /// {
+        ///     public MyPluginController() : base(UmbracoContextHelper.EnsureContext())
+        ///     {
+        ///         public ActionResult MyAction(int nodeId)
+        ///         {
+        ///             var node = UmbracoContext.ContentCache.GetById(nodeId);
+        ///         }
+        ///     }
+        /// }
+        /// </example>
         /// <param name="replaceContext">Whether to replace the current context if it already exists (defaults to false)</param>
         /// <returns></returns>
         public static UmbracoContext EnsureContext(bool replaceContext = false)

--- a/Endzone.Umbraco.Extensions/Helpers/UmbracoContextHelper.cs
+++ b/Endzone.Umbraco.Extensions/Helpers/UmbracoContextHelper.cs
@@ -1,0 +1,31 @@
+﻿using System.Web;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Web;
+using Umbraco.Web.Routing;
+using Umbraco.Web.Security;
+
+namespace Endzone.Umbraco.Extensions.Helpers
+{
+    public class UmbracoContextHelper
+    {
+        /// <summary>
+        /// Ensures UmbracoContext exists for current request by either using existing one, or creating one based on the current request.
+        /// </summary>
+        /// <param name="replaceContext">Whether to replace the current context if it already exists (defaults to false)</param>
+        /// <returns></returns>
+        public static UmbracoContext EnsureContext(bool replaceContext = false)
+        {
+            var httpContext = new HttpContextWrapper(HttpContext.Current);
+            var applicationContext = ApplicationContext.Current;
+
+            return UmbracoContext.EnsureContext(
+                httpContext,
+                applicationContext,
+                new WebSecurity(httpContext, applicationContext),
+                UmbracoConfig.For.UmbracoSettings(),
+                UrlProviderResolver.Current.Providers,
+                replaceContext);
+        }
+    }
+}

--- a/Endzone.Umbraco.Extensions/PropertyValueConverters/SwitcherValueConverter.cs
+++ b/Endzone.Umbraco.Extensions/PropertyValueConverters/SwitcherValueConverter.cs
@@ -1,0 +1,41 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+
+namespace Endzone.Umbraco.Extensions.PropertyValueConverters
+{
+    /// <summary>
+    /// PropertyValueConverter which converts the value stored for a Switcher data type to a boolean.
+    /// </summary>
+    [PropertyValueType(typeof(bool))]
+    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.ContentCache)]
+    public class SwitcherValueConverter : IPropertyValueConverter
+    {
+        public bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.PropertyEditorAlias.Equals("Our.Umbraco.Switcher");
+        }
+
+        public object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var attemptConvertBool = source.TryConvertTo<bool>();
+
+            if (attemptConvertBool.Success)
+            {
+                return attemptConvertBool.Result;
+            }
+
+            return null;
+        }
+
+        public object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            return source;
+        }
+
+        public object ConvertSourceToXPath(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            return source?.ToString();
+        }
+    }
+}


### PR DESCRIPTION
PropertyValueConverter for the Switcher data type that we use, so it returns a 'strongly-typed' boolean when generating models in ModelsBuilder.

UmbracoContextHelper with a method to create an UmbracoContext outside of the Umbraco request pipeline. This will be useful when trying to work with the content cache in things like sitemap generation or scheduled tasks.