### PR TITLE
Added option to use UmbracoContext in background tasks.

### DIFF
--- a/Endzone.Umbraco.Extensions/Helpers/UmbracoContextHelper.cs
+++ b/Endzone.Umbraco.Extensions/Helpers/UmbracoContextHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Web;
+﻿using System.IO;
+using System.Web;
+using System.Web.Hosting;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
 using Umbraco.Web;
@@ -29,7 +31,7 @@ namespace Endzone.Umbraco.Extensions.Helpers
         /// <returns></returns>
         public static UmbracoContext EnsureContext(bool replaceContext = false)
         {
-            var httpContext = new HttpContextWrapper(HttpContext.Current);
+            var httpContext = new HttpContextWrapper(HttpContext.Current ?? CreateHttpContext());
             var applicationContext = ApplicationContext.Current;
 
             return UmbracoContext.EnsureContext(
@@ -39,6 +41,18 @@ namespace Endzone.Umbraco.Extensions.Helpers
                 UmbracoConfig.For.UmbracoSettings(),
                 UrlProviderResolver.Current.Providers,
                 replaceContext);
+        }
+
+        /// <summary>
+        /// Creates an HttpContext instance based on a dummy request.
+        /// </summary>
+        /// <example>
+        /// Will be used when there is no real HttpContext, for example in tasks running on a background thread.
+        /// </example>
+        /// <returns></returns>
+        private static HttpContext CreateHttpContext()
+        {
+            return new HttpContext(new SimpleWorkerRequest("/", string.Empty, new StringWriter()));
         }
     }
 }

--- a/Endzone.Umbraco.Extensions/PublishedContentExtensions/Configuration.cs
+++ b/Endzone.Umbraco.Extensions/PublishedContentExtensions/Configuration.cs
@@ -42,13 +42,14 @@ namespace Endzone.Umbraco.Extensions.PublishedContentExtensions
 
         /// <summary>
         /// Gets the strongly typed auxiliary content (e.g. website settings) for the current site.
-        /// Example:
+        /// </summary>
+        /// <example>
         /// Homepage node has a composition doc type of AuxiliaryFolder (strongly-typed interface: IAuxiliaryFolder)
         /// which has a property called WebsiteSettings (MNTP limited to doc type WebsiteSettings).
         /// To get the website settings on the current node call: 
         /// Model.GetAuxiliaryContent&lt;IAuxiliaryFolder, WebsiteSettings&gt;(x => x.WebsiteSettings)
         /// This will return the selected WebsiteSettings node with its strongly-typed model.
-        /// </summary>
+        /// </example>
         /// <param name="content"></param>
         /// <param name="property">The strongly typed property that contains the MNTP value for the auxiliary content</param>
         /// <returns></returns>


### PR DESCRIPTION
This allows the UmbracoContextHelper to be used in background tasks when there is no current HttpContext available, but we still want access to the Umbraco content cache.