### PR TITLE
Don't attach empty email attachments.

### DIFF
--- a/Endzone.Umbraco.Extensions/Services/EmailService.cs
+++ b/Endzone.Umbraco.Extensions/Services/EmailService.cs
@@ -49,7 +49,7 @@ namespace Endzone.Umbraco.Extensions.Services
                     foreach (string key in files)
                     {
                         HttpPostedFile file = files[key];
-                        if (file == null) continue;
+                        if (file == null || file.ContentLength == 0) continue;
                         string fileName = Path.GetFileName(file.FileName);
                         var attachment = new Attachment(file.InputStream, fileName);
                         mail.Attachments.Add(attachment);


### PR DESCRIPTION
If a form is submitted with an optional file upload field, the HttpFileCollection passed into this function might not be empty, but the file(s) contained it still can be.

This can cause issues when trying to send emails through Postmark (which blocks emails with empty attachments), so therefore I've added an additional check for the content length of the attachment file to only attach it when it's a non-empty file.